### PR TITLE
7.29 updates

### DIFF
--- a/scripts/rebuild_constants.sql
+++ b/scripts/rebuild_constants.sql
@@ -1,0 +1,26 @@
+
+\c :db_name
+
+DROP TABLE heroes, hero_aliases, items;
+
+CREATE TABLE heroes (
+    id INT PRIMARY KEY UNIQUE,
+    name TEXT NOT NULL UNIQUE,
+    localized_name TEXT NOT NULL UNIQUE,
+    primary_attr VARCHAR(3),
+    roles TEXT[]
+);
+
+CREATE TABLE hero_aliases (
+    id SERIAL PRIMARY KEY UNIQUE,
+    hero_id INT NOT NULL,
+    alias TEXT NOT NULL UNIQUE,
+    CONSTRAINT fk_hero
+        FOREIGN KEY(hero_id)
+        REFERENCES heroes(id)
+);
+
+CREATE TABLE items (
+    id INT PRIMARY KEY,
+    item_name TEXT UNIQUE
+);

--- a/scripts/reload_constants.sh
+++ b/scripts/reload_constants.sh
@@ -10,4 +10,4 @@ psql -U $POSTGRES_USER \
     -f rebuild_constants.sql 
 
 cd ..
-python ./scripts/seed.py
+python3 ./scripts/seed.py

--- a/scripts/reload_constants.sh
+++ b/scripts/reload_constants.sh
@@ -1,0 +1,10 @@
+cd ./scripts
+source ../.env
+
+PGPASSWORD=$POSTGRES_PASSWORD \
+psql -U $POSTGRES_USER \
+    -h localhost \
+    -p $DATABASE_PORT \
+    -v db_name=$POSTGRES_DB \
+    -d $POSTGRES_DB \
+    -f rebuild_constants.sql 

--- a/scripts/reload_constants.sh
+++ b/scripts/reload_constants.sh
@@ -8,3 +8,6 @@ psql -U $POSTGRES_USER \
     -v db_name=$POSTGRES_DB \
     -d $POSTGRES_DB \
     -f rebuild_constants.sql 
+
+cd ..
+python ./scripts/seed.py

--- a/scripts/reload_constants.sh
+++ b/scripts/reload_constants.sh
@@ -1,3 +1,4 @@
+
 cd ./scripts
 source ../.env
 
@@ -10,4 +11,4 @@ psql -U $POSTGRES_USER \
     -f rebuild_constants.sql 
 
 cd ..
-python3 ./scripts/seed.py
+./scripts/seed.py

--- a/src/constant_data/aliases.json
+++ b/src/constant_data/aliases.json
@@ -254,5 +254,9 @@
   {
     "id": 121,
     "aliases": ["Grim"]
+  },
+  {
+    "id": 135,
+    "aliases": ["Dawn", "Dawn breaker", "Womniknight"]
   }
 ]

--- a/src/constant_data/heroes.json
+++ b/src/constant_data/heroes.json
@@ -1677,5 +1677,17 @@
             "Durable"
         ],
         "legs": 2
+    },
+    {
+        "id": 135,
+        "name": "npc_dota_hero_dawnbreaker",
+        "localized_name": "Dawnbreaker",
+        "primary_attr": "str",
+        "attack_type": "Melee",
+        "roles": [
+            "Carry",
+            "Durable"
+        ],
+        "legs": 2
     }
 ]

--- a/src/constant_data/items.json
+++ b/src/constant_data/items.json
@@ -242,7 +242,7 @@
       {
         "key": "bonus_armor",
         "header": "+",
-        "value": "5",
+        "value": "6",
         "footer": "Armor"
       },
       {
@@ -352,7 +352,7 @@
   "quelling_blade": {
     "hint": [
       "Active: Chop Tree Destroy a target tree. Cast Range: 350",
-      "Passive: Quell Increases attack damage against non-hero units by 13 for melee heroes, and 6 for ranged."
+      "Passive: Quell Increases attack damage against non-hero units by 12 for melee heroes, and 6 for ranged."
     ],
     "id": 11,
     "img": "/apps/dota2/images/items/quelling_blade_lg.png?t=1593393829403",
@@ -395,7 +395,7 @@
   },
   "infused_raindrop": {
     "hint": [
-      "Passive: Magical Damage Block Consumes a charge to block 120 magic damage from damage instances over 50 damage. Comes with 6 charges. When the charges are gone, the item disappears."
+      "Passive: Magical Damage Block Consumes a charge to block 120 magic damage from damage instances over 75 damage. Comes with 6 charges. When the charges are gone, the item disappears."
     ],
     "id": 265,
     "img": "/apps/dota2/images/items/infused_raindrop_lg.png?t=1593393829403",
@@ -517,7 +517,7 @@
     "img": "/apps/dota2/images/items/gauntlets_lg.png?t=1593393829403",
     "dname": "Gauntlets of Strength",
     "qual": "component",
-    "cost": 145,
+    "cost": 140,
     "notes": "",
     "attrib": [
       {
@@ -539,7 +539,7 @@
     "img": "/apps/dota2/images/items/slippers_lg.png?t=1593393829403",
     "dname": "Slippers of Agility",
     "qual": "component",
-    "cost": 145,
+    "cost": 140,
     "notes": "",
     "attrib": [
       {
@@ -561,7 +561,7 @@
     "img": "/apps/dota2/images/items/mantle_lg.png?t=1593393829403",
     "dname": "Mantle of Intelligence",
     "qual": "component",
-    "cost": 145,
+    "cost": 140,
     "notes": "",
     "attrib": [
       {
@@ -1024,7 +1024,7 @@
     "img": "/apps/dota2/images/items/talisman_of_evasion_lg.png?t=1593393829403",
     "dname": "Talisman of Evasion",
     "qual": "secret_shop",
-    "cost": 1400,
+    "cost": 1300,
     "notes": "Stacks diminishingly with other sources of Evasion.",
     "attrib": [
       {
@@ -1147,7 +1147,7 @@
   },
   "clarity": {
     "hint": [
-      "Use: Replenish Grants 6 mana regeneration to the target for 30 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: 250"
+      "Use: Replenish Grants 6 mana regeneration to the target for 25 seconds.If the unit is attacked by an enemy hero or Roshan, the effect is lost.Range: 250"
     ],
     "id": 38,
     "img": "/apps/dota2/images/items/clarity_lg.png?t=1593393829403",
@@ -1226,14 +1226,14 @@
   },
   "bottle": {
     "hint": [
-      "Active: RegenerateConsumes a charge to restore 125 health and 75 mana over 2.5 seconds. If the hero is attacked by an enemy hero or Roshan, the effect is lost.The Bottle automatically refills at the fountain.Hold Control to use on an allied hero.Range: 350",
+      "Active: RegenerateConsumes a charge to restore 115 health and 65 mana over 2.5 seconds. If the hero is attacked by an enemy hero or Roshan, the effect is lost.The Bottle automatically refills at the fountain.Hold Control to use on an allied hero.Range: 350",
       "Passive:  Store RuneRunes can be stored in the bottle for later use by right-clicking them. Unused runes will automatically activate after 2 minutes.Using a stored rune fully refills the Bottle."
     ],
     "id": 41,
     "img": "/apps/dota2/images/items/bottle_lg.png?t=1593393829403",
     "dname": "Bottle",
     "qual": "common",
-    "cost": 625,
+    "cost": 675,
     "notes": "Bottle is shareable. Stored runes cannot be shared.\nIf Bottle does not have full charges and is placed on a courier, the courier's movement speed will be slowed by 30%.",
     "attrib": [],
     "mc": false,
@@ -1245,7 +1245,7 @@
   },
   "ward_observer": {
     "hint": [
-      "Use: PlantPlants an Observer Ward, an invisible watcher that gives ground vision in a 1400 radius to your team. Lasts 6 minutes.Hold Control to give one Observer Ward to an allied hero.Range: 500"
+      "Use: PlantPlants an Observer Ward, an invisible watcher that gives ground vision in a 1600 radius to your team. Lasts 6 minutes.Hold Control to give one Observer Ward to an allied hero.Range: 500"
     ],
     "id": 42,
     "img": "/apps/dota2/images/items/ward_observer_lg.png?t=1593393829403",
@@ -1270,13 +1270,13 @@
   },
   "ward_sentry": {
     "hint": [
-      "Use: Plant Plants a Sentry Ward, an invisible watcher that grants True Sight, the ability to see invisible enemy units and wards, to any existing allied vision within a 1000 radius.Lasts 8 minutes.Does not grant ground vision.Hold Control to give one Sentry Ward to an allied hero.Range: 500"
+      "Use: Plant Plants a Sentry Ward, an invisible watcher that grants True Sight, the ability to see invisible enemy units and wards, to any existing allied vision within a 900 radius.Lasts 8 minutes.Does not grant ground vision.Hold Control to give one Sentry Ward to an allied hero.Range: 500"
     ],
     "id": 43,
     "img": "/apps/dota2/images/items/ward_sentry_lg.png?t=1593393829403",
     "dname": "Sentry Ward",
     "qual": "consumable",
-    "cost": 75,
+    "cost": 50,
     "notes": "",
     "attrib": [
       {
@@ -1301,13 +1301,13 @@
     "img": "/apps/dota2/images/items/ward_dispenser_lg.png?t=1593393829403",
     "dname": "Observer and Sentry Wards",
     "qual": "common",
-    "cost": 75,
+    "cost": 50,
     "notes": "Hold Control to give one ward to an allied hero.",
     "attrib": [
       {
         "key": "observer_vision_range_tooltip",
         "header": "OBSERVER VISION RANGE:",
-        "value": "1400"
+        "value": "1600"
       },
       {
         "key": "observer_duration_minutes_tooltip",
@@ -1317,7 +1317,7 @@
       {
         "key": "true_sight_range",
         "header": "SENTRY TRUE SIGHT RANGE:",
-        "value": "1000"
+        "value": "900"
       },
       {
         "key": "sentry_duration_minutes_tooltip",
@@ -1365,7 +1365,7 @@
     "notes": "",
     "attrib": [],
     "mc": false,
-    "cd": 60,
+    "cd": false,
     "lore": "Om nom nom.",
     "components": null,
     "created": false,
@@ -1415,7 +1415,7 @@
     "img": "/apps/dota2/images/items/tpscroll_lg.png?t=1593393829403",
     "dname": "Town Portal Scroll",
     "qual": "consumable",
-    "cost": 90,
+    "cost": 100,
     "notes": "If multiple heroes teleport to the same location in succession, the channeling time will be increased for each successive hero.\nTeleport can be prevented or canceled by Root abilities.",
     "attrib": [],
     "mc": 75,
@@ -1454,7 +1454,7 @@
       {
         "key": "bonus_movement_speed",
         "header": "+",
-        "value": "110",
+        "value": "100",
         "footer": "Movement Speed"
       },
       {
@@ -1487,7 +1487,7 @@
       {
         "key": "bonus_movement_speed",
         "header": "+",
-        "value": "130",
+        "value": "120",
         "footer": "Movement Speed"
       },
       {
@@ -1733,7 +1733,7 @@
     "img": "/apps/dota2/images/items/energy_booster_lg.png?t=1593393829403",
     "dname": "Energy Booster",
     "qual": "secret_shop",
-    "cost": 900,
+    "cost": 800,
     "notes": "",
     "attrib": [
       {
@@ -1783,7 +1783,7 @@
     "img": "/apps/dota2/images/items/vitality_booster_lg.png?t=1593393829403",
     "dname": "Vitality Booster",
     "qual": "secret_shop",
-    "cost": 1100,
+    "cost": 1000,
     "notes": "",
     "attrib": [
       {
@@ -1980,7 +1980,7 @@
   },
   "witch_blade": {
     "hint": [
-      "Passive: Witch BladeCauses your next attack to apply a poison for 3 seconds, slowing by 25% and dealing 1x your intelligence as damage every second."
+      "Passive: Witch BladeCauses your next attack to apply a poison for 3 seconds, slowing by 25% and dealing 1x your intelligence as damage every second. This attack has True Strike."
     ],
     "id": 534,
     "img": "/apps/dota2/images/items/witch_blade_lg.png?t=1593393829403",
@@ -2125,7 +2125,7 @@
     "img": "/apps/dota2/images/items/bracer_lg.png?t=1593393829403",
     "dname": "Bracer",
     "qual": "common",
-    "cost": 510,
+    "cost": 505,
     "notes": "",
     "attrib": [
       {
@@ -2155,7 +2155,7 @@
       {
         "key": "bonus_health_regen",
         "header": "+",
-        "value": "0.75",
+        "value": "1",
         "footer": "HP Regeneration"
       }
     ],
@@ -2188,7 +2188,7 @@
     "img": "/apps/dota2/images/items/wraith_band_lg.png?t=1593393829403",
     "dname": "Wraith Band",
     "qual": "common",
-    "cost": 510,
+    "cost": 505,
     "notes": "",
     "attrib": [
       {
@@ -2251,7 +2251,7 @@
     "img": "/apps/dota2/images/items/null_talisman_lg.png?t=1593393829403",
     "dname": "Null Talisman",
     "qual": "common",
-    "cost": 510,
+    "cost": 505,
     "notes": "",
     "attrib": [
       {
@@ -2311,7 +2311,7 @@
   "mekansm": {
     "hint": [
       "Active: RestoreHeals 275 health to allied units in a 1200 radius.",
-      "Passive: Mekansm AuraGrants 2 health regeneration to allied units in a 1200 radius."
+      "Passive: Mekansm AuraGrants 2.5 health regeneration to allied units in a 1200 radius."
     ],
     "id": 79,
     "img": "/apps/dota2/images/items/mekansm_lg.png?t=1593393829403",
@@ -2327,7 +2327,7 @@
         "footer": "Armor"
       }
     ],
-    "mc": 200,
+    "mc": 100,
     "cd": 65,
     "lore": "A glowing jewel formed out of assorted parts that somehow fit together perfectly.",
     "components": [
@@ -2341,7 +2341,7 @@
     "id": 80,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Vladmir's Offering Recipe",
-    "cost": 600,
+    "cost": 500,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -2353,13 +2353,13 @@
   },
   "vladmir": {
     "hint": [
-      "Passive: Vladmir's AuraGrants 15% lifesteal, 18% bonus damage, 1.4 mana regeneration, and 3 armor to nearby allies. Radius: 1200"
+      "Passive: Vladmir's AuraGrants 15% lifesteal, 18% bonus damage, 1.75 mana regeneration, and 3 armor to nearby allies. Radius: 1200"
     ],
     "id": 81,
     "img": "/apps/dota2/images/items/vladmir_lg.png?t=1593393829403",
     "dname": "Vladmir's Offering",
     "qual": "rare",
-    "cost": 2750,
+    "cost": 2700,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -2378,7 +2378,7 @@
     "id": 85,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Buckler Recipe",
-    "cost": 200,
+    "cost": 250,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -2396,9 +2396,16 @@
     "img": "/apps/dota2/images/items/buckler_lg.png?t=1593393829403",
     "dname": "Buckler",
     "qual": "rare",
-    "cost": 375,
+    "cost": 425,
     "notes": "",
-    "attrib": [],
+    "attrib": [
+      {
+        "key": "armor",
+        "header": "+",
+        "value": "1",
+        "footer": "Armor"
+      }
+    ],
     "mc": false,
     "cd": false,
     "lore": "A powerful shield that imbues the bearer with the strength of heroes past, it is capable of protecting entire armies in battle.",
@@ -2411,6 +2418,7 @@
   "recipe_ring_of_basilius": {
     "id": 87,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
+    "dname": "Ring of Basilius Recipe",
     "cost": 250,
     "notes": "",
     "attrib": [],
@@ -2423,7 +2431,7 @@
   },
   "ring_of_basilius": {
     "hint": [
-      "Passive: Basilius AuraGrants 1.4 mana regeneration to allies.  Radius: 1200"
+      "Passive: Basilius AuraGrants 1 mana regeneration to allies.  Radius: 1200"
     ],
     "id": 88,
     "img": "/apps/dota2/images/items/ring_of_basilius_lg.png?t=1593393829403",
@@ -2431,7 +2439,14 @@
     "qual": "rare",
     "cost": 425,
     "notes": "",
-    "attrib": [],
+    "attrib": [
+      {
+        "key": "mana_regen",
+        "header": "+",
+        "value": "0.6",
+        "footer": "Mana Regeneration"
+      }
+    ],
     "mc": false,
     "cd": false,
     "lore": "Ring given as a reward to the greatest mages.",
@@ -2457,7 +2472,7 @@
   },
   "holy_locket": {
     "hint": [
-      "Active: Energy ChargeTarget an allied unit to instantly restore 15 health and mana per charge stored. Max 20 charges. Automatically gains a charge every 15 seconds and whenever a visible enemy within 1200 range uses an ability.",
+      "Active: Energy ChargeTarget an allied unit to instantly restore 15 health and mana per charge stored. Max 20 charges. Automatically gains a charge every 10 seconds and whenever a visible enemy within 1200 range uses an ability.",
       "",
       "Passive: Holy BlessingAmplifies heals you provide by 35%.",
       "",
@@ -2467,7 +2482,7 @@
     "img": "/apps/dota2/images/items/holy_locket_lg.png?t=1593393829403",
     "dname": "Holy Locket",
     "qual": "rare",
-    "cost": 2500,
+    "cost": 2400,
     "notes": "",
     "attrib": [
       {
@@ -2518,7 +2533,7 @@
   "pipe": {
     "hint": [
       "Active: BarrierGives a shield that blocks 400 magic damage to all nearby allies. Lasts 12 seconds.Radius: 1200",
-      "Passive: Insight Aura Gives allied units 2 health regeneration and 10% magic resistance.Radius: 1200"
+      "Passive: Insight Aura Gives allied units 2.5 health regeneration and 10% magic resistance.Radius: 1200"
     ],
     "id": 90,
     "img": "/apps/dota2/images/items/pipe_lg.png?t=1593393829403",
@@ -2578,7 +2593,7 @@
       {
         "key": "mana_regen",
         "header": "+",
-        "value": "1.5",
+        "value": "1.4",
         "footer": "Mana Regeneration"
       },
       {
@@ -2629,7 +2644,14 @@
     "qual": "rare",
     "cost": 425,
     "notes": "",
-    "attrib": [],
+    "attrib": [
+      {
+        "key": "health_regen",
+        "header": "+",
+        "value": "0.5",
+        "footer": "HP Regeneration"
+      }
+    ],
     "mc": false,
     "cd": false,
     "lore": "Creates a soothing aura that restores allies in battle.",
@@ -2676,7 +2698,7 @@
       }
     ],
     "mc": 250,
-    "cd": 22,
+    "cd": 20,
     "lore": "The most guarded relic among the cult of Vyse, it is the most coveted weapon among magi.",
     "components": [
       "mystic_staff",
@@ -2750,7 +2772,7 @@
     "id": 245,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Bloodthorn Recipe",
-    "cost": 1000,
+    "cost": 800,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -2768,7 +2790,7 @@
     "img": "/apps/dota2/images/items/bloodthorn_lg.png?t=1593393829403",
     "dname": "Bloodthorn",
     "qual": "epic",
-    "cost": 6475,
+    "cost": 6275,
     "notes": "Critical Strike does not work against buildings.",
     "attrib": [
       {
@@ -2826,7 +2848,7 @@
       {
         "key": "bonus_strength",
         "header": "+",
-        "value": "12",
+        "value": "15",
         "footer": "Strength"
       },
       {
@@ -2874,7 +2896,7 @@
   },
   "cyclone": {
     "hint": [
-      "Active: Cyclone Sweeps a target unit up into a cyclone, making them invulnerable for 2.5 seconds. Cyclone can only be cast on enemy units or yourself.Enemy units take 50 magical damage upon landing.Range: 575Dispel Type: Basic Dispel"
+      "Active: Cyclone Sweeps a target unit up into a cyclone, making them invulnerable for 2.5 seconds. Cyclone can only be cast on enemy units or yourself.Enemy units take 50 magical damage upon landing.Range: 550Dispel Type: Basic Dispel"
     ],
     "id": 100,
     "img": "/apps/dota2/images/items/cyclone_lg.png?t=1593393829403",
@@ -2929,7 +2951,7 @@
   },
   "wind_waker": {
     "hint": [
-      "Active: Cyclone Sweeps a target unit up into a cyclone, making them invulnerable for 2.5 seconds. Cyclone can be cast on yourself, enemy units or allied units.Enemy units take 50 magical damage upon landing.Range: 575Dispel Type: Basic Dispel"
+      "Active: Cyclone Sweeps a target unit up into a cyclone, making them invulnerable for 2.5 seconds. Cyclone can be cast on yourself, enemy units or allied units.Enemy units take 50 magical damage upon landing.Range: 550Dispel Type: Basic Dispel"
     ],
     "id": 610,
     "img": "/apps/dota2/images/items/wind_waker_lg.png?t=1593393829403",
@@ -2958,7 +2980,7 @@
       }
     ],
     "mc": 175,
-    "cd": 23,
+    "cd": 18,
     "lore": "Proof enough to some that unseen forces manipulate the happenings of the material plane.",
     "components": [
       "cyclone",
@@ -2971,7 +2993,7 @@
     "id": 233,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Aether Lens Recipe",
-    "cost": 550,
+    "cost": 650,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -2983,7 +3005,7 @@
   },
   "aether_lens": {
     "hint": [
-      "Passive: Aethereal Focus Increases targeted spell and item cast range by 250."
+      "Passive: Aethereal Focus Increases targeted spell and item cast range by 225."
     ],
     "id": 232,
     "img": "/apps/dota2/images/items/aether_lens_lg.png?t=1593393829403",
@@ -3019,7 +3041,7 @@
     "id": 101,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Force Staff Recipe",
-    "cost": 1000,
+    "cost": 950,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -3037,7 +3059,7 @@
     "img": "/apps/dota2/images/items/force_staff_lg.png?t=1593393829403",
     "dname": "Force Staff",
     "qual": "rare",
-    "cost": 2175,
+    "cost": 2200,
     "notes": "Self-cast will cause you to use Force on yourself.\nForce Staff doesn't interrupt the target's actions.\nWill not work on a unit inside Chronosphere, Duel, or Black Hole.",
     "attrib": [
       {
@@ -3047,10 +3069,10 @@
         "footer": "Intelligence"
       },
       {
-        "key": "bonus_health_regen",
+        "key": "bonus_health",
         "header": "+",
-        "value": "2.5",
-        "footer": "HP Regeneration"
+        "value": "150",
+        "footer": "Health"
       }
     ],
     "mc": 100,
@@ -3058,7 +3080,7 @@
     "lore": "Allows you to manipulate others, for good or evil.",
     "components": [
       "staff_of_wizardry",
-      "ring_of_regen"
+      "fluffy_hat"
     ],
     "created": true,
     "charges": false
@@ -3086,20 +3108,20 @@
     "img": "/apps/dota2/images/items/hurricane_pike_lg.png?t=1593393829403",
     "dname": "Hurricane Pike",
     "qual": "epic",
-    "cost": 4525,
+    "cost": 4550,
     "notes": "Self-cast will use Hurricane Pike on yourself.\nHurricane Pike doesn't interrupt the target's actions.\nWill not work on a unit inside Chronosphere, Duel, or Black Hole.",
     "attrib": [
       {
         "key": "bonus_intellect",
         "header": "+",
-        "value": "13",
+        "value": "15",
         "footer": "Intelligence"
       },
       {
-        "key": "bonus_health_regen",
+        "key": "bonus_health",
         "header": "+",
-        "value": "2.5",
-        "footer": "HP Regeneration"
+        "value": "200",
+        "footer": "Health"
       },
       {
         "key": "bonus_agility",
@@ -3128,7 +3150,7 @@
     "id": 103,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Dagon Recipe",
-    "cost": 1300,
+    "cost": 1250,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -3140,13 +3162,13 @@
   },
   "dagon": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 700,750,800,850,900Mana Cost: 120,140,160,180,200"
     ],
     "id": 104,
     "img": "/apps/dota2/images/items/dagon_lg.png?t=1593393829403",
     "dname": "Dagon",
     "qual": "rare",
-    "cost": 2750,
+    "cost": 2700,
     "notes": "Instantly kills illusions.",
     "attrib": [
       {
@@ -3198,13 +3220,13 @@
   },
   "dagon_2": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 700,750,800,850,900Mana Cost: 120,140,160,180,200"
     ],
     "id": 201,
     "img": "/apps/dota2/images/items/dagon_2_lg.png?t=1593393829403",
     "dname": "Dagon",
     "qual": "rare",
-    "cost": 4050,
+    "cost": 3950,
     "notes": "Instantly kills illusions.",
     "attrib": [
       {
@@ -3256,13 +3278,13 @@
   },
   "dagon_3": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 700,750,800,850,900Mana Cost: 120,140,160,180,200"
     ],
     "id": 202,
     "img": "/apps/dota2/images/items/dagon_3_lg.png?t=1593393829403",
     "dname": "Dagon",
     "qual": "rare",
-    "cost": 5350,
+    "cost": 5200,
     "notes": "Instantly kills illusions.",
     "attrib": [
       {
@@ -3314,13 +3336,13 @@
   },
   "dagon_4": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit. Upgradable.Damage: 400,500,600,700,800Range: 700,750,800,850,900Mana Cost: 120,140,160,180,200"
     ],
     "id": 203,
     "img": "/apps/dota2/images/items/dagon_4_lg.png?t=1593393829403",
     "dname": "Dagon",
     "qual": "rare",
-    "cost": 6650,
+    "cost": 6450,
     "notes": "Instantly kills illusions.",
     "attrib": [
       {
@@ -3372,13 +3394,13 @@
   },
   "dagon_5": {
     "hint": [
-      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit.Damage: 400,500,600,700,800Range: 600,650,700,750,800Mana Cost: 120,140,160,180,200"
+      "Active: Energy Burst Emits a powerful burst of magical damage upon a targeted enemy unit.Damage: 400,500,600,700,800Range: 700,750,800,850,900Mana Cost: 120,140,160,180,200"
     ],
     "id": 204,
     "img": "/apps/dota2/images/items/dagon_5_lg.png?t=1593393829403",
     "dname": "Dagon",
     "qual": "rare",
-    "cost": 7950,
+    "cost": 7700,
     "notes": "Instantly kills illusions.",
     "attrib": [
       {
@@ -3444,7 +3466,7 @@
   },
   "necronomicon": {
     "hint": [
-      "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 700,800,900Damage: 48,62,78Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 700,800,900Damage: 37,57,75Aura Move Speed: 5,7,9Aura Radius: 1200"
+      "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 800,1200,1600Damage: 25,45,65Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 800,1200,1600Damage: 37,57,75Aura Move Speed: 5,7,9Aura Radius: 1200"
     ],
     "id": 106,
     "img": "/apps/dota2/images/items/necronomicon_lg.png?t=1593393829403",
@@ -3487,7 +3509,7 @@
   },
   "necronomicon_2": {
     "hint": [
-      "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 700,800,900Damage: 48,62,78Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 700,800,900Damage: 37,57,75Aura Move Speed: 5,7,9Aura Radius: 1200"
+      "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 800,1200,1600Damage: 25,45,65Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 800,1200,1600Damage: 37,57,75Aura Move Speed: 5,7,9Aura Radius: 1200"
     ],
     "id": 193,
     "img": "/apps/dota2/images/items/necronomicon_2_lg.png?t=1593393829403",
@@ -3529,7 +3551,7 @@
   },
   "necronomicon_3": {
     "hint": [
-      "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 700,800,900Damage: 48,62,78Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 700,800,900Damage: 37,57,75Aura Move Speed: 5,7,9Aura Radius: 1200"
+      "Active: Demonic SummoningSummons a Warrior and an Archer to fight for you for 60 seconds.Warrior:Burns mana every hit, and deals magical damage to whoever kills it.  Gains True Sight at level 3.Health: 800,1200,1600Damage: 25,45,65Mana Break Damage: 30,40,50Last Will Damage: 600,700,800Archer:Has a passive movement and attack speed aura. Gains Purge at Level 3.Health: 800,1200,1600Damage: 37,57,75Aura Move Speed: 5,7,9Aura Radius: 1200"
     ],
     "id": 194,
     "img": "/apps/dota2/images/items/necronomicon_3_lg.png?t=1593393829403",
@@ -3645,6 +3667,24 @@
     "created": true,
     "charges": false
   },
+  "ultimate_scepter_roshan": {
+    "hint": [
+      "Passive: Ability UpgradeUpgrades the ultimate, and some abilities, of all heroes."
+    ],
+    "id": 727,
+    "img": "/apps/dota2/images/items/ultimate_scepter_roshan_lg.png?t=1593393829403",
+    "dname": "Aghanim's Blessing - Roshan",
+    "qual": "rare",
+    "cost": 5800,
+    "notes": "",
+    "attrib": [],
+    "mc": false,
+    "cd": false,
+    "lore": "The scepter of a wizard with demigod-like powers.",
+    "components": null,
+    "created": false,
+    "charges": false
+  },
   "aghanims_shard": {
     "hint": [
       "Passive: Ability UpgradeUpgrades one of your abilities."
@@ -3652,6 +3692,24 @@
     "id": 609,
     "img": "/apps/dota2/images/items/aghanims_shard_lg.png?t=1593393829403",
     "dname": "Aghanim's Shard",
+    "qual": "rare",
+    "cost": 1400,
+    "notes": "",
+    "attrib": [],
+    "mc": false,
+    "cd": false,
+    "lore": "With origins known only to a single wizard, fragments of this impossible crystal are nearly as coveted as the renowned scepter itself.",
+    "components": null,
+    "created": false,
+    "charges": false
+  },
+  "aghanims_shard_roshan": {
+    "hint": [
+      "Passive: Ability UpgradeUpgrades one of your abilities."
+    ],
+    "id": 725,
+    "img": "/apps/dota2/images/items/aghanims_shard_roshan_lg.png?t=1593393829403",
+    "dname": "Aghanim's Shard - Roshan",
     "qual": "rare",
     "cost": 1400,
     "notes": "",
@@ -3733,7 +3791,7 @@
     "img": "/apps/dota2/images/items/assault_lg.png?t=1593393829403",
     "dname": "Assault Cuirass",
     "qual": "epic",
-    "cost": 5075,
+    "cost": 5125,
     "notes": "",
     "attrib": [
       {
@@ -3764,7 +3822,7 @@
     "id": 113,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Heart of Tarrasque Recipe",
-    "cost": 900,
+    "cost": 1300,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -3779,7 +3837,7 @@
     "img": "/apps/dota2/images/items/heart_lg.png?t=1593393829403",
     "dname": "Heart of Tarrasque",
     "qual": "epic",
-    "cost": 4800,
+    "cost": 5100,
     "notes": "",
     "attrib": [
       {
@@ -3826,7 +3884,7 @@
   },
   "black_king_bar": {
     "hint": [
-      "Active: Avatar Grants Spell Immunity.  Duration decreases with each use. Duration: 10,9,8,7,6,5 Dispel Type: Basic Dispel"
+      "Active: Avatar Grants Spell Immunity.  Duration decreases with each use. Duration: 9,8,7,6 Dispel Type: Basic Dispel"
     ],
     "id": 116,
     "img": "/apps/dota2/images/items/black_king_bar_lg.png?t=1593393829403",
@@ -3849,7 +3907,7 @@
       }
     ],
     "mc": false,
-    "cd": 70,
+    "cd": 75,
     "lore": "A powerful staff imbued with the strength of giants.",
     "components": [
       "ogre_axe",
@@ -3916,7 +3974,7 @@
       }
     ],
     "mc": 100,
-    "cd": 30,
+    "cd": 27,
     "lore": "Said to have belonged to a goddess, today it retains much of its former power.",
     "components": [
       "platemail",
@@ -3934,7 +3992,7 @@
     "img": "/apps/dota2/images/items/bloodstone_lg.png?t=1593393829403",
     "dname": "Bloodstone",
     "qual": "epic",
-    "cost": 5950,
+    "cost": 5750,
     "notes": "",
     "attrib": [
       {
@@ -4055,7 +4113,7 @@
     "img": "/apps/dota2/images/items/lotus_orb_lg.png?t=1593393829403",
     "dname": "Lotus Orb",
     "qual": "epic",
-    "cost": 3950,
+    "cost": 3850,
     "notes": "",
     "attrib": [
       {
@@ -4109,7 +4167,7 @@
   },
   "meteor_hammer": {
     "hint": [
-      "Active: Meteor Hammer CHANNELED - After a successful channel, summons a meteor that strikes a 315 AoE, stunning enemies for 1.75 seconds and dealing impact damage. Continues to deal damage over time to enemies units and buildings for 6 seconds.Building Impact Damage: 75 Building Over Time Damage: 50 Non-Building Impact Damage: 150 Non-Building Over Time Damage: 90 Channel Duration: 2.5 seconds.Landing Time: 0.5 seconds."
+      "Active: Meteor Hammer CHANNELED - After a successful channel, summons a meteor that strikes a 315 AoE, stunning enemies for 1.5 seconds and dealing impact damage. Continues to deal damage over time to enemies units and buildings for 6 seconds.Building Impact Damage: 75 Building Over Time Damage: 60 Non-Building Impact Damage: 150 Non-Building Over Time Damage: 90 Channel Duration: 2.5 seconds.Landing Time: 0.5 seconds."
     ],
     "id": 223,
     "img": "/apps/dota2/images/items/meteor_hammer_lg.png?t=1593393829403",
@@ -4191,7 +4249,7 @@
     "id": 255,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Aeon Disk Recipe",
-    "cost": 1100,
+    "cost": 1200,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -4209,7 +4267,7 @@
     "img": "/apps/dota2/images/items/aeon_disk_lg.png?t=1593393829403",
     "dname": "Aeon Disk",
     "qual": "epic",
-    "cost": 3100,
+    "cost": 3000,
     "notes": "",
     "attrib": [
       {
@@ -4271,7 +4329,7 @@
       {
         "key": "mana_regen_multiplier",
         "header": "+Mana Regen Amplification",
-        "value": "24%"
+        "value": "50%"
       },
       {
         "key": "spell_lifesteal_amp",
@@ -4420,7 +4478,7 @@
     "img": "/apps/dota2/images/items/spirit_vessel_lg.png?t=1593393829403",
     "dname": "Spirit Vessel",
     "qual": "rare",
-    "cost": 2940,
+    "cost": 2840,
     "notes": "",
     "attrib": [
       {
@@ -4460,13 +4518,13 @@
   },
   "vanguard": {
     "hint": [
-      "Passive: Damage Block Grants a 50% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
+      "Passive: Damage Block Grants a 60% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
     ],
     "id": 125,
     "img": "/apps/dota2/images/items/vanguard_lg.png?t=1593393829403",
     "dname": "Vanguard",
     "qual": "epic",
-    "cost": 1925,
+    "cost": 1825,
     "notes": "Multiple sources of damage block do not stack.",
     "attrib": [
       {
@@ -4509,13 +4567,13 @@
   "crimson_guard": {
     "hint": [
       "Active: Guard For 12 seconds, grant nearby allied heroes and buildings a 100% chance to block 70 damage from each incoming attack.Units may only be affected by Guard once every 40 seconds.Radius: 1200",
-      "Passive: Damage Block Grants a 50% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
+      "Passive: Damage Block Grants a 60% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
     ],
     "id": 242,
     "img": "/apps/dota2/images/items/crimson_guard_lg.png?t=1593393829403",
     "dname": "Crimson Guard",
     "qual": "epic",
-    "cost": 3800,
+    "cost": 3700,
     "notes": "Multiple sources of damage block do not stack.",
     "attrib": [
       {
@@ -4551,7 +4609,7 @@
     "id": 126,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Blade Mail Recipe",
-    "cost": 675,
+    "cost": 575,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -4570,7 +4628,7 @@
     "img": "/apps/dota2/images/items/blade_mail_lg.png?t=1593393829403",
     "dname": "Blade Mail",
     "qual": "epic",
-    "cost": 2225,
+    "cost": 2125,
     "notes": "Damage Return is calculated before any kind of reduction.\nDamage Return doesn't reflect damage from other forms of Blade Mail.\nReturned damage type is the same as it was received.",
     "attrib": [
       {
@@ -4601,7 +4659,7 @@
     "img": "/apps/dota2/images/items/soul_booster_lg.png?t=1593393829403",
     "dname": "Soul Booster",
     "qual": "epic",
-    "cost": 3200,
+    "cost": 3000,
     "notes": "",
     "attrib": [
       {
@@ -4738,9 +4796,7 @@
   },
   "rapier": {
     "hint": [
-      "Passive: Everlasting Dropped on death, and cannot be destroyed. Becomes unusable if picked up by an ally of its owner until it is returned to its owner. It is immediately usable by anybody if an enemy of the owner picks it up and is killed. A dropped Rapier cannot be picked up by a courier.",
-      "",
-      " Passive: True Strike Your attacks cannot miss."
+      "Passive: Everlasting Dropped on death, and cannot be destroyed. Becomes unusable if picked up by an ally of its owner until it is returned to its owner. It is immediately usable by anybody if an enemy of the owner picks it up and is killed. A dropped Rapier cannot be picked up by a courier."
     ],
     "id": 133,
     "img": "/apps/dota2/images/items/rapier_lg.png?t=1593393829403",
@@ -4752,7 +4808,7 @@
       {
         "key": "bonus_damage",
         "header": "+",
-        "value": "300",
+        "value": "350",
         "footer": "Damage"
       }
     ],
@@ -4782,7 +4838,7 @@
   },
   "monkey_king_bar": {
     "hint": [
-      "Passive: PierceGrants each attack a 75% chance to pierce through evasion and deal 70 bonus magical damage."
+      "Passive: PierceGrants each attack a 80% chance to pierce through evasion and deal 70 bonus magical damage."
     ],
     "id": 135,
     "img": "/apps/dota2/images/items/monkey_king_bar_lg.png?t=1593393829403",
@@ -4861,7 +4917,7 @@
     "img": "/apps/dota2/images/items/butterfly_lg.png?t=1593393829403",
     "dname": "Butterfly",
     "qual": "epic",
-    "cost": 5075,
+    "cost": 4975,
     "notes": "Stacks diminishingly with other sources of Evasion.",
     "attrib": [
       {
@@ -4994,7 +5050,7 @@
     "hint": [
       "Active: Chop Tree Destroy a target tree.Cast Range: 350",
       "Passive: Quell Increases attack damage against non-hero units by 18 for melee heroes, and 6 for ranged. ",
-      "Passive: Cleave Deals 70% of attack damage as physical damage in a cone up to 650 around the target. Deals 50% against creeps. (Melee Only)"
+      "Passive: Cleave Deals 70% of attack damage as physical damage in a cone up to 650 around the target. Deals 40% against creeps. (Melee Only)"
     ],
     "id": 145,
     "img": "/apps/dota2/images/items/bfury_lg.png?t=1593393829403",
@@ -5018,7 +5074,7 @@
       {
         "key": "bonus_mana_regen",
         "header": "+",
-        "value": "3.25",
+        "value": "2.75",
         "footer": "Mana Regeneration"
       }
     ],
@@ -5050,7 +5106,7 @@
   },
   "manta": {
     "hint": [
-      "Active: Mirror ImageCreates 2 images of your hero that last 20 seconds. Melee images deal 33% damage and take 350% damage, while Ranged images deal 28% and take 400% damage. Cooldown increased by 15 seconds on ranged heroes.Dispel Type: Basic Dispel"
+      "Active: Mirror ImageCreates 2 images of your hero that last 20 seconds. Melee images deal 33% damage, while Ranged images deal 28%. Illusions take %tooltip_damage_incoming_melee_total_pct%% damage Cooldown increased by %tooltip_ranged_cooldown_increase% seconds on ranged heroes.Dispel Type: Basic Dispel"
     ],
     "id": 147,
     "img": "/apps/dota2/images/items/manta_lg.png?t=1593393829403",
@@ -5091,7 +5147,7 @@
       }
     ],
     "mc": 125,
-    "cd": 45,
+    "cd": 30,
     "lore": "An axe made of reflective materials that causes confusion amongst enemy ranks.",
     "components": [
       "yasha",
@@ -5156,7 +5212,7 @@
       {
         "key": "bonus_agility",
         "header": "+",
-        "value": "14",
+        "value": "16",
         "footer": "Agility"
       },
       {
@@ -5193,7 +5249,7 @@
   },
   "armlet": {
     "hint": [
-      "Toggle: Unholy StrengthWhen active, Unholy Strength grants +35 damage, +25 strength and +4 armor, but drains 50 health per second. You cannot die from the health drain when Unholy Strength is activated, nor from the strength loss when Unholy Strength is deactivated."
+      "Toggle: Unholy StrengthWhen active, Unholy Strength grants +35 damage, +25 strength and +4 armor, but drains 40 health per second. You cannot die from the health drain when Unholy Strength is activated, nor from the strength loss when Unholy Strength is deactivated."
     ],
     "id": 151,
     "img": "/apps/dota2/images/items/armlet_lg.png?t=1593393829403",
@@ -5217,7 +5273,7 @@
       {
         "key": "bonus_armor",
         "header": "+",
-        "value": "5",
+        "value": "6",
         "footer": "Armor"
       },
       {
@@ -5263,7 +5319,7 @@
       }
     ],
     "mc": 75,
-    "cd": 28,
+    "cd": 25,
     "lore": "The blade of a fallen king, it allows you to move unseen and strike from the shadows.",
     "components": [
       "shadow_amulet",
@@ -5313,13 +5369,13 @@
       {
         "key": "bonus_intellect",
         "header": "+",
-        "value": "10",
+        "value": "15",
         "footer": "Intelligence"
       },
       {
         "key": "bonus_mana_regen",
         "header": "+",
-        "value": "3",
+        "value": "4",
         "footer": "Mana Regeneration"
       }
     ],
@@ -5361,7 +5417,7 @@
       {
         "key": "bonus_attack_speed",
         "header": "+",
-        "value": "16",
+        "value": "12",
         "footer": "Attack Speed"
       },
       {
@@ -5414,7 +5470,7 @@
       {
         "key": "mana_regen_multiplier",
         "header": "+Mana Regen Amplification",
-        "value": "30%"
+        "value": "50%"
       },
       {
         "key": "spell_amp",
@@ -5465,13 +5521,13 @@
       {
         "key": "bonus_attack_speed",
         "header": "+",
-        "value": "16",
+        "value": "12",
         "footer": "Attack Speed"
       },
       {
         "key": "mana_regen_multiplier",
         "header": "+Mana Regen Amplification",
-        "value": "30%"
+        "value": "50%"
       },
       {
         "key": "movement_speed_percent_bonus",
@@ -5502,7 +5558,7 @@
   },
   "satanic": {
     "hint": [
-      "Active: Unholy RageIncreases Lifesteal percentage to 200% for 6 seconds. ",
+      "Active: Unholy RageIncreases Lifesteal percentage to 200% for 6 seconds. Dispel Type: Basic Dispel ",
       "Passive: LifestealHeals the attacker for 25% of attack damage dealt."
     ],
     "id": 156,
@@ -5526,7 +5582,7 @@
       }
     ],
     "mc": false,
-    "cd": 35,
+    "cd": 25,
     "lore": "Immense power at the cost of your soul.",
     "components": [
       "lifesteal",
@@ -5552,8 +5608,8 @@
   },
   "mjollnir": {
     "hint": [
-      "Active: Static ChargePlaces a charged shield on a target unit for 15 seconds which has a 20% chance to release a 200 magical damage shocking bolt at a nearby attacker and 4 additional enemies.Range: 800",
-      "Passive: Chain LightningGrants a 30% chance on attack to release a bolt of electricity that leaps between 12 targets within a 650 radius, dealing 170 magical damage to each. Lightning proc pierces evasion."
+      "Active: Static ChargePlaces a charged shield on a target unit for 15 seconds which has a 20% chance to release a 225 magical damage shocking bolt at a nearby attacker and 4 additional enemies.Range: 800",
+      "Passive: Chain LightningGrants a 30% chance on attack to release a bolt of electricity that leaps between 12 targets within a 650 radius, dealing 180 magical damage to each. Lightning proc pierces evasion."
     ],
     "id": 158,
     "img": "/apps/dota2/images/items/mjollnir_lg.png?t=1593393829403",
@@ -5691,7 +5747,7 @@
   },
   "helm_of_the_dominator": {
     "hint": [
-      "Active: DominateTakes control of one neutral, non-ancient target unit and sets its movement speed to 425 and max health to a minimum of 1000. Also provides the unit with +25 base attack damage, +12 health regen, +4 mana regen and +4 armor. Dominated units with a max health of greater than 1000 retain their original max health.  Dominated unit's bounty is set to 200 gold.Range: 700"
+      "Active: DominateTakes control of one neutral, non-ancient target unit and sets its movement speed to 380 and max health to a minimum of 1000. Also provides the unit with +25 base attack damage, +12 health regen, +4 mana regen and +4 armor. Dominated units with a max health of greater than 1000 retain their original max health.  Dominated unit's bounty is set to 100 gold.Range: 700"
     ],
     "id": 164,
     "img": "/apps/dota2/images/items/helm_of_the_dominator_lg.png?t=1593393829403",
@@ -5729,10 +5785,10 @@
     "created": true,
     "charges": false
   },
-  "recipe_helm_of_the_dominator_2": {
+  "recipe_helm_of_the_overlord": {
     "id": 633,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
-    "dname": "Helm of the Dominator Level 2 Recipe",
+    "dname": "Helm of the Overlord Recipe",
     "cost": 1600,
     "notes": "",
     "attrib": [],
@@ -5743,13 +5799,13 @@
     "created": false,
     "charges": false
   },
-  "helm_of_the_dominator_2": {
+  "helm_of_the_overlord": {
     "hint": [
-      "Active: DominateTakes control of one neutral target unit and sets its movement speed to 425 and max health to a minimum of 1800. Also provides the unit with +25 base attack damage, +12 health regen, +4 mana regen and +4 armor. Dominated units with a max health of greater than 1800 retain their original max health.  Dominated unit's bounty is set to 200 gold.Range: 700"
+      "Active: DominateTakes control of one neutral target unit and sets its movement speed to 380 and max health to a minimum of 1800. Also provides the unit with +25 base attack damage, +12 health regen, +4 mana regen and +4 armor. Dominated units with a max health of greater than 1800 retain their original max health.  Dominated unit's bounty is set to 150 gold.Range: 700"
     ],
     "id": 635,
-    "img": "/apps/dota2/images/items/helm_of_the_dominator_2_lg.png?t=1593393829403",
-    "dname": "Helm of the Dominator",
+    "img": "/apps/dota2/images/items/helm_of_the_overlord_lg.png?t=1593393829403",
+    "dname": "Helm of the Overlord",
     "qual": "artifact",
     "cost": 6000,
     "notes": "Cannot dominate more than one unit at a time.  If a new unit is dominated, the old one will die.\nCan also Dominate enemy lane creeps and summoned units.\nSelling Helm of the Dominator will cause dominated units to die.",
@@ -5814,6 +5870,7 @@
   "recipe_gungir": {
     "id": 1565,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
+    "dname": "Gleipnir Recipe",
     "cost": 700,
     "notes": "",
     "attrib": [],
@@ -5965,12 +6022,6 @@
     "notes": "",
     "attrib": [
       {
-        "key": "bonus_damage",
-        "header": "+",
-        "value": "10",
-        "footer": "Damage"
-      },
-      {
         "key": "bonus_attack_speed",
         "header": "+",
         "value": "10",
@@ -6004,7 +6055,7 @@
   "diffusal_blade": {
     "hint": [
       "Active: Inhibit Targets an enemy, slowing it for 4 seconds.Range: 600",
-      "Passive: ManabreakEach attack burns 40 mana from the target, and deals 0.8 physical damage per burned mana. Burns 16 mana per attack from melee illusions and 8 mana per attack from ranged illusions."
+      "Passive: ManabreakEach attack burns 40 mana from the target, and deals 1 physical damage per burned mana. Burns 12 mana per attack from melee illusions and 8 mana per attack from ranged illusions."
     ],
     "id": 174,
     "img": "/apps/dota2/images/items/diffusal_blade_lg.png?t=1593393829403",
@@ -6016,13 +6067,13 @@
       {
         "key": "bonus_agility",
         "header": "+",
-        "value": "20",
+        "value": "24",
         "footer": "Agility"
       },
       {
         "key": "bonus_intellect",
         "header": "+",
-        "value": "10",
+        "value": "12",
         "footer": "Intelligence"
       }
     ],
@@ -6081,7 +6132,7 @@
     "id": 177,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Soul Ring Recipe",
-    "cost": 275,
+    "cost": 225,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -6099,7 +6150,7 @@
     "img": "/apps/dota2/images/items/soul_ring_lg.png?t=1593393829403",
     "dname": "Soul Ring",
     "qual": "common",
-    "cost": 740,
+    "cost": 680,
     "notes": "If this mana is not used before the duration ends, the extra mana is lost.",
     "attrib": [
       {
@@ -6135,7 +6186,7 @@
     "img": "/apps/dota2/images/items/arcane_boots_lg.png?t=1593393829403",
     "dname": "Arcane Boots",
     "qual": "rare",
-    "cost": 1400,
+    "cost": 1300,
     "notes": "Does not work on Meepo clones.",
     "attrib": [
       {
@@ -6169,13 +6220,13 @@
     "img": "/apps/dota2/images/items/octarine_core_lg.png?t=1593393829403",
     "dname": "Octarine Core",
     "qual": "rare",
-    "cost": 5475,
+    "cost": 5275,
     "notes": "",
     "attrib": [
       {
         "key": "cast_range_bonus",
         "header": "+",
-        "value": "250",
+        "value": "225",
         "footer": "Cast Range"
       },
       {
@@ -6246,6 +6297,7 @@
   "recipe_orb_of_corrosion": {
     "id": 640,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
+    "dname": "Orb of Corrosion Recipe",
     "cost": 100,
     "notes": "",
     "attrib": [],
@@ -6341,7 +6393,7 @@
     "id": 597,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Mage Slayer Recipe",
-    "cost": 600,
+    "cost": 400,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -6359,7 +6411,7 @@
     "img": "/apps/dota2/images/items/mage_slayer_lg.png?t=1593393829403",
     "dname": "Mage Slayer",
     "qual": "rare",
-    "cost": 3450,
+    "cost": 3250,
     "notes": "",
     "attrib": [
       {
@@ -6481,7 +6533,8 @@
   "recipe_solar_crest": {
     "id": 227,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
-    "cost": 450,
+    "dname": "Solar Crest Recipe",
+    "cost": 900,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -6493,25 +6546,25 @@
   },
   "solar_crest": {
     "hint": [
-      "Active: ShineWhen cast on an ally, grants them 8 armor, 80 attack speed, and 10% movement speed. When cast on an enemy, removes 8 armor, 80 attack speed, and 10% movement speed.Removes the armor from the caster when used.  Cannot target spell immune enemies.Range: 1000"
+      "Active: ShineWhen cast on an ally, grants them 6 armor, 65 attack speed, and 10% movement speed. When cast on an enemy, removes 6 armor, 65 attack speed, and 10% movement speed.Removes the armor from the caster when used.  Cannot target spell immune enemies.Range: 1000"
     ],
     "id": 229,
     "img": "/apps/dota2/images/items/solar_crest_lg.png?t=1593393829403",
     "dname": "Solar Crest",
     "qual": "rare",
-    "cost": 3775,
+    "cost": 2625,
     "notes": "",
     "attrib": [
       {
         "key": "bonus_armor",
         "header": "+",
-        "value": "8",
+        "value": "6",
         "footer": "Armor"
       },
       {
         "key": "bonus_all_stats",
         "header": "+",
-        "value": "10",
+        "value": "5",
         "footer": "All Attributes"
       },
       {
@@ -6532,7 +6585,7 @@
     "lore": "A talisman forged to honor the daytime sky.",
     "components": [
       "medallion_of_courage",
-      "ultimate_orb",
+      "crown",
       "wind_lace"
     ],
     "created": true,
@@ -6590,9 +6643,9 @@
   },
   "veil_of_discord": {
     "hint": [
-      "Active: Magic Weakness Cast a 600 radius blast that causes enemy heroes to take 18% increased damage from spells.Range: 1000Duration: 16 seconds. ",
+      "Active: Magic Weakness Cast a 600 radius blast that causes enemy heroes to take 18% increased damage from spells.Range: 1200Duration: 16 seconds. ",
       "",
-      "Passive: Basilius AuraGrants 1.5 mana regeneration to allies.  Radius: 1200"
+      "Passive: Basilius AuraGrants 1.75 mana regeneration to allies.  Radius: 1200"
     ],
     "id": 190,
     "img": "/apps/dota2/images/items/veil_of_discord_lg.png?t=1593393829403",
@@ -6609,7 +6662,7 @@
       }
     ],
     "mc": 50,
-    "cd": 25,
+    "cd": 22,
     "lore": "The headwear of corrupt magi.",
     "components": [
       "ring_of_basilius",
@@ -6642,7 +6695,7 @@
     "img": "/apps/dota2/images/items/guardian_greaves_lg.png?t=1593393829403",
     "dname": "Guardian Greaves",
     "qual": "rare",
-    "cost": 5250,
+    "cost": 5200,
     "notes": "The aura boost only applies to heroes.",
     "attrib": [
       {
@@ -6782,7 +6835,7 @@
     "id": 207,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
     "dname": "Abyssal Blade Recipe",
-    "cost": 1750,
+    "cost": 1550,
     "notes": "",
     "attrib": [],
     "mc": false,
@@ -6794,15 +6847,15 @@
   },
   "abyssal_blade": {
     "hint": [
-      "Active: Overwhelm Blinks to and stuns a target enemy unit for 2 seconds. Pierces Spell Immunity.Range: 550",
+      "Active: Overwhelm Stuns a target enemy unit for 2 seconds. Pierces Spell Immunity.Range: 150",
       "Passive: Bash Grants melee heroes a 25% chance on hit to stun the target for 1.5 seconds and deal 100 bonus physical damage.  Bash chance for ranged heroes is 10%.",
-      "Passive: Damage Block Grants a 50% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
+      "Passive: Damage Block Grants a 60% chance to block 70 damage from incoming attacks on melee heroes, and 35 damage on ranged."
     ],
     "id": 208,
     "img": "/apps/dota2/images/items/abyssal_blade_lg.png?t=1593393829403",
     "dname": "Abyssal Blade",
     "qual": "epic",
-    "cost": 6625,
+    "cost": 6325,
     "notes": "The stun is melee range.\nDoes not stack with other bashes.\nMultiple sources of damage block do not stack.",
     "attrib": [
       {
@@ -6862,7 +6915,7 @@
     "img": "/apps/dota2/images/items/heavens_halberd_lg.png?t=1593393829403",
     "dname": "Heaven's Halberd",
     "qual": "artifact",
-    "cost": 3650,
+    "cost": 3550,
     "notes": "",
     "attrib": [
       {
@@ -6945,7 +6998,7 @@
   },
   "tranquil_boots": {
     "hint": [
-      "Passive: Break Whenever you attack a hero or are attacked by any unit, the bonus 14 HP regen is lost and the movement speed bonus is reduced to 45 for 13 seconds.",
+      "Passive: Break Whenever you attack a hero or are attacked by any unit, the bonus 14 HP regen is lost and the movement speed bonus is reduced to 40 for 13 seconds.",
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 214,
@@ -6958,7 +7011,7 @@
       {
         "key": "bonus_movement_speed",
         "header": "+",
-        "value": "70",
+        "value": "65",
         "footer": "Movement Speed"
       },
       {
@@ -6999,6 +7052,7 @@
   "recipe_glimmer_cape": {
     "id": 253,
     "img": "/apps/dota2/images/items/recipe_lg.png?t=1593393829403",
+    "dname": "Glimmer Cape Recipe",
     "cost": 450,
     "notes": "",
     "attrib": [],
@@ -7254,7 +7308,7 @@
   },
   "grove_bow": {
     "hint": [
-      "Passive: Magic Amp Reduces magic resistance of the attacked enemy by 12%."
+      "Passive: Magic Amp Reduces magic resistance of the attacked enemy by 15%."
     ],
     "id": 288,
     "img": "/apps/dota2/images/items/grove_bow_lg.png?t=1593393829403",
@@ -7309,9 +7363,6 @@
     "tier": 3
   },
   "philosophers_stone": {
-    "hint": [
-      "Increases gold income and mana, while reducing outgoing attack damage."
-    ],
     "id": 290,
     "img": "/apps/dota2/images/items/philosophers_stone_lg.png?t=1593393829403",
     "dname": "Philosopher's Stone",
@@ -7321,7 +7372,7 @@
       {
         "key": "bonus_gpm",
         "header": "+GPM BONUS",
-        "value": "70"
+        "value": "80"
       },
       {
         "key": "bonus_mana",
@@ -7360,6 +7411,12 @@
         "header": "+",
         "value": "115",
         "footer": "Movement Speed"
+      },
+      {
+        "key": "hp_regen",
+        "header": "+",
+        "value": "30",
+        "footer": "HP Regeneration"
       }
     ],
     "mc": 75,
@@ -7414,7 +7471,7 @@
   },
   "seer_stone": {
     "hint": [
-      "Active: Reveal Reveal a target 800 area of the map for 5 seconds."
+      "Active: Reveal Reveal a target 800 area of the map for 6 seconds."
     ],
     "id": 294,
     "img": "/apps/dota2/images/items/seer_stone_lg.png?t=1593393829403",
@@ -7441,7 +7498,7 @@
       }
     ],
     "mc": false,
-    "cd": 70,
+    "cd": 60,
     "lore": "The curious creation of a wizard who professed to hail from another time.",
     "components": null,
     "created": false,
@@ -7700,8 +7757,7 @@
     "lore": "To those who harvest olgru jelly, success serves more than mere profit--it's often the means to survival--for only the jelly itself can cure the ravages that follow a sting from the vigilant denizens of the giant hives.",
     "components": null,
     "created": false,
-    "charges": 2,
-    "tier": 1
+    "charges": 2
   },
   "pupils_gift": {
     "hint": [
@@ -7716,7 +7772,7 @@
       {
         "key": "secondary_stats",
         "header": "+SECONDARY STATS",
-        "value": "13"
+        "value": "14"
       }
     ],
     "mc": false,
@@ -7771,7 +7827,7 @@
   },
   "mind_breaker": {
     "hint": [
-      "Passive: Silence Strike The next attack silences the hit enemy for 1.5 seconds."
+      "Passive: Silence Strike The next attack silences the hit enemy for 1.75 seconds."
     ],
     "id": 309,
     "img": "/apps/dota2/images/items/mind_breaker_lg.png?t=1593393829403",
@@ -7781,17 +7837,17 @@
     "attrib": [
       {
         "key": "magic_damage",
-        "header": "MAGIC ATTACK BONUS DAMAGE:",
+        "header": "+Magic Attack Damage",
         "value": "25"
       },
       {
         "key": "attack_speed",
-        "header": "ATTACK SPEED:",
+        "header": "+Attack Speed",
         "value": "25"
       }
     ],
     "mc": false,
-    "cd": 15,
+    "cd": 12,
     "lore": "A bewitching blade of indeterminate form capable of piercing the psyche of even the most willful foe.",
     "components": null,
     "created": false,
@@ -7841,7 +7897,7 @@
       {
         "key": "bonus_all_stats",
         "header": "+",
-        "value": "12",
+        "value": "6",
         "footer": "All Attributes"
       },
       {
@@ -7923,7 +7979,7 @@
       {
         "key": "bonus_damage",
         "header": "+",
-        "value": "24",
+        "value": "26",
         "footer": "Damage"
       }
     ],
@@ -7937,7 +7993,7 @@
   },
   "flicker": {
     "hint": [
-      "Active: Flicker Dispells debuffs and blinks you to a random spot within 450 range. Does not get disabled on incoming damage."
+      "Active: Flicker Dispells debuffs and blinks you in a random forward direction for a random distance between 200 and 600. Does not get disabled on incoming damage."
     ],
     "id": 335,
     "img": "/apps/dota2/images/items/flicker_lg.png?t=1593393829403",
@@ -7948,7 +8004,7 @@
       {
         "key": "bonus_movement_speed",
         "header": "+",
-        "value": "40",
+        "value": "35",
         "footer": "Movement Speed"
       }
     ],
@@ -7978,12 +8034,12 @@
       {
         "key": "attack_range",
         "header": "AURA BONUS ATTACK RANGE:",
-        "value": "135"
+        "value": "125"
       },
       {
         "key": "cast_range",
         "header": "AURA BONUS CAST RANGE:",
-        "value": "135"
+        "value": "125"
       }
     ],
     "mc": false,
@@ -7996,7 +8052,7 @@
   },
   "spider_legs": {
     "hint": [
-      "Active: Scurry Grants you 24% bonus movement speed and free pathing for 3 seconds. Walking over trees causes them to be destroyed.",
+      "Active: Scurry Grants you 22% bonus movement speed and free pathing for 3 seconds. Walking over trees causes them to be destroyed.",
       "Movement speed bonuses from multiple pairs of boots do not stack."
     ],
     "id": 326,
@@ -8118,7 +8174,7 @@
   },
   "ocean_heart": {
     "hint": [
-      "Passive: Water Regen Provides you with 8 HP regen and 4 mana regen while in the river."
+      "Passive: Water Regen Provides you with 10 HP regen and 5 mana regen while in the river."
     ],
     "id": 354,
     "img": "/apps/dota2/images/items/ocean_heart_lg.png?t=1593393829403",
@@ -8157,7 +8213,7 @@
       {
         "key": "bonus_damage",
         "header": "+",
-        "value": "12",
+        "value": "14",
         "footer": "Damage"
       },
       {
@@ -8177,7 +8233,7 @@
   },
   "trusty_shovel": {
     "hint": [
-      "Active: Dig Channel for 1 second. Can find a Bounty Rune, a Flask, a TP Scroll, or an enemy Kobold."
+      "Active: Dig Channel for 1 second. Can find a Bounty Rune, a Flask, an Enchanted Mango, or an enemy Kobold."
     ],
     "id": 356,
     "img": "/apps/dota2/images/items/trusty_shovel_lg.png?t=1593393829403",
@@ -8201,9 +8257,6 @@
     "tier": 1
   },
   "nether_shawl": {
-    "hint": [
-      "Increases the wearer's magic resistance and magic damage, while decreasing their armor."
-    ],
     "id": 357,
     "img": "/apps/dota2/images/items/nether_shawl_lg.png?t=1593393829403",
     "dname": "Nether Shawl",
@@ -8359,13 +8412,13 @@
       {
         "key": "bonus_agility",
         "header": "+",
-        "value": "20",
+        "value": "24",
         "footer": "Agility"
       },
       {
         "key": "passive_movement_bonus",
         "header": "+",
-        "value": "30",
+        "value": "25",
         "footer": "Movement Speed"
       }
     ],
@@ -8380,7 +8433,7 @@
   "illusionsts_cape": {
     "hint": [
       "Active: Create Illusion Creates an image under your control. ",
-      "Passive: Illusion MasteryIncreases outgoing damage of all units and illusions controlled by the hero by 8%."
+      "Passive: Illusion MasteryIncreases outgoing damage of all units and illusions controlled by the hero by 6%."
     ],
     "id": 363,
     "img": "/apps/dota2/images/items/illusionsts_cape_lg.png?t=1593393829403",
@@ -8575,7 +8628,7 @@
   },
   "demonicon": {
     "hint": [
-      "Active: Greater Demonic Summoning Summon 2 sets of Level 3 Necronomicon Units that last 75 seconds. Units have 100% more health and 50% more damage."
+      "Active: Greater Demonic Summoning Summon 2 sets of Level 3 Necronomicon Units that last 75 seconds. Units have 100% more health and 75% more damage."
     ],
     "id": 370,
     "img": "/apps/dota2/images/items/demonicon_lg.png?t=1593393829403",
@@ -8597,7 +8650,7 @@
       }
     ],
     "mc": false,
-    "cd": 90,
+    "cd": 80,
     "lore": "A record of the final reckoning. With one page torn out.",
     "components": null,
     "created": false,
@@ -8709,7 +8762,7 @@
   },
   "ex_machina": {
     "hint": [
-      "Active: Reset Item Cooldowns Reset the cooldown on all items (except Refresher Orb)."
+      "Active: Reset Cooldowns Reset the cooldown on all items (except Refresher Orb)."
     ],
     "id": 374,
     "img": "/apps/dota2/images/items/ex_machina_lg.png?t=1593393829403",
@@ -8725,7 +8778,7 @@
       }
     ],
     "mc": false,
-    "cd": 30,
+    "cd": 25,
     "lore": "The remains of an ancient universe, preserved within a single sphere.",
     "components": null,
     "created": false,
@@ -8780,6 +8833,11 @@
         "key": "bonus_lifesteal",
         "header": "+Lifesteal",
         "value": "16%"
+      },
+      {
+        "key": "bonus_spell_lifesteal",
+        "header": "+Spell Lifesteal",
+        "value": "8%"
       }
     ],
     "mc": false,
@@ -8864,8 +8922,14 @@
       {
         "key": "bonus_attack_speed",
         "header": "+",
-        "value": "60",
+        "value": "50",
         "footer": "Attack Speed"
+      },
+      {
+        "key": "bonus_armor",
+        "header": "+",
+        "value": "5",
+        "footer": "Armor"
       },
       {
         "key": "demolish",
@@ -8913,9 +8977,6 @@
     "tier": 1
   },
   "titan_sliver": {
-    "hint": [
-      "Increases the wearer's attack damage, magic and status resistance."
-    ],
     "id": 381,
     "img": "/apps/dota2/images/items/titan_sliver_lg.png?t=1593393829403",
     "dname": "Titan Sliver",
@@ -8950,7 +9011,7 @@
   },
   "chipped_vest": {
     "hint": [
-      "PassiveEverytime you are attacked, you return 28 damage to heroes and 17 damage to creeps."
+      "PassiveEverytime you are attacked, you return 30 damage to heroes and 20 damage to creeps."
     ],
     "id": 565,
     "img": "/apps/dota2/images/items/chipped_vest_lg.png?t=1593393829403",
@@ -8961,7 +9022,7 @@
       {
         "key": "hp_regen",
         "header": "+",
-        "value": "3.5",
+        "value": "5",
         "footer": "HP Regeneration"
       }
     ],
@@ -9047,7 +9108,7 @@
       {
         "key": "movment",
         "header": "+",
-        "value": "8%",
+        "value": "7%",
         "footer": "Movement Speed"
       }
     ],
@@ -9162,7 +9223,7 @@
     ],
     "id": 576,
     "img": "/apps/dota2/images/items/gladiator_helm_lg.png?t=1593393829403",
-    "dname": "Gladiator Helm",
+    "dname": "Helm of the Gladiator",
     "cost": 0,
     "notes": "",
     "attrib": [],
@@ -9262,7 +9323,7 @@
   },
   "penta_edged_sword": {
     "hint": [
-      "Passive: MaimEach attack has a 20% chance to reduce enemy hero movement speed by 20% and attack speed by 60 for 3 seconds."
+      "Passive: MaimEach attack has a 25% chance to reduce enemy hero movement speed by 20% and attack speed by 60 for 3 seconds."
     ],
     "id": 638,
     "img": "/apps/dota2/images/items/penta_edged_sword_lg.png?t=1593393829403",
@@ -9279,7 +9340,7 @@
       {
         "key": "melee_attack_range",
         "header": "+",
-        "value": "80",
+        "value": "100",
         "footer": "Attack Range (Melee Only)"
       }
     ],
@@ -9341,7 +9402,7 @@
   },
   "bullwhip": {
     "hint": [
-      "Active: WhipGrants 20% movement speed when cast on allies, and slows by 20% when cast on enemies. Lasts 4 seconds."
+      "Active: WhipGrants 18% movement speed when cast on allies, and slows by 18% when cast on enemies. Lasts 4 seconds."
     ],
     "id": 680,
     "img": "/apps/dota2/images/items/bullwhip_lg.png?t=1593393829403",
@@ -9358,12 +9419,12 @@
       {
         "key": "bonus_mana_regen",
         "header": "+",
-        "value": "3",
+        "value": "2.5",
         "footer": "Mana Regeneration"
       }
     ],
     "mc": false,
-    "cd": 12,
+    "cd": 11,
     "lore": "Once the favored lash of an infamous broker of pit fighters and other live trade.",
     "components": null,
     "created": false,
@@ -9383,7 +9444,7 @@
       {
         "key": "intelligence_pct",
         "header": "+Intelligence",
-        "value": "12%"
+        "value": "16%"
       },
       {
         "key": "cast_range",
@@ -9427,7 +9488,7 @@
   },
   "quicksilver_amulet": {
     "hint": [
-      "Passive: QuicksilverGrants you a bonus 5% movement speed and 15 attack speed anytime one of your abilities are on cooldown."
+      "Passive: QuicksilverGrants you a bonus 4% movement speed and 20 attack speed anytime one of your abilities are on cooldown."
     ],
     "id": 686,
     "img": "/apps/dota2/images/items/quicksilver_amulet_lg.png?t=1593393829403",
@@ -9438,7 +9499,7 @@
       {
         "key": "base_movement",
         "header": "+",
-        "value": "5%",
+        "value": "4%",
         "footer": "Movement Speed"
       },
       {
@@ -9450,12 +9511,12 @@
       {
         "key": "anim_increase",
         "header": "+Attack Animation Speed",
-        "value": "30%"
+        "value": "40%"
       },
       {
         "key": "projectile_increase",
         "header": "+Attack Projectile Speed",
-        "value": "30%"
+        "value": "40%"
       }
     ],
     "mc": false,
@@ -9489,7 +9550,7 @@
       }
     ],
     "mc": false,
-    "cd": 15,
+    "cd": 8,
     "lore": "An impossible tome filled with unreadable prose of unknowable thoughts.",
     "components": null,
     "created": false,


### PR DESCRIPTION
This pr updates the constants in `heroes.json`, `hero_aliases.json` and `items.json` to 7.29 values and adds Dawnbreaker. It also adds a script to reload the constants in the database (`heroes`, `hero_aliases` and `items` tables) without dropping the entire database/users table, try it by running `./scripts/reload_constants.sh` in slarkbot root.