### PR TITLE
quote=False on sticker messages

### DIFF
--- a/src/bot/message_handlers/feel_bad.py
+++ b/src/bot/message_handlers/feel_bad.py
@@ -15,4 +15,4 @@ def feel_bad(update, context):
 
     if any(x in text.lower() for x in text_options):
         update.message.reply_text("I'm sorry :(")
-        update.message.reply_sticker("CAACAgUAAxkBAAMfYLf_RpX-kk6gSyxd0_2gj9t9V3YAAhYCAAJfDwsGTRekwVeT3LUfBA")
+        update.message.reply_sticker("CAACAgUAAxkBAAMfYLf_RpX-kk6gSyxd0_2gj9t9V3YAAhYCAAJfDwsGTRekwVeT3LUfBA", quote=False)

--- a/src/bot/message_handlers/youre_welcome.py
+++ b/src/bot/message_handlers/youre_welcome.py
@@ -14,4 +14,4 @@ def say_youre_welcome(update, context):
 
     if any(x in text.lower() for x in text_options):
         update.message.reply_text("You're welcome :)")
-        update.message.reply_sticker("CAACAgQAAx0CPjTD9AABC2m9YLfsTcojjSPl7L_DFbWS3IWrp34AAocAA_tjggqQUNMScJneeB8E")
+        update.message.reply_sticker("CAACAgQAAx0CPjTD9AABC2m9YLfsTcojjSPl7L_DFbWS3IWrp34AAocAA_tjggqQUNMScJneeB8E", quote=False)


### PR DESCRIPTION
Small change to make sure that both sticker replies, since they immediately follow a quote reply, do not ping the user they're replying to again. The sticker is still sent in the right place, it just doesn't direct-reply. Closes #92 