### PR TITLE
Add nemistice game mode

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -122,6 +122,7 @@ LOBBY_TYPE_MAP = {
     7: "Ranked",
     8: "1v1 Mid",
     9: "Battle Cup",
+    12: "Nemistice"
 }
 
 GAME_MODE_MAP = {


### PR DESCRIPTION
Slarkbot crashes on nemistice lobbies. Adds lobby type `12` to lobby map to show nemistice games