### PR TITLE
/lastmatch with hero argument

### DIFF
--- a/src/bot/commands/match_commands.py
+++ b/src/bot/commands/match_commands.py
@@ -3,27 +3,54 @@ from src import constants
 from src.bot.models.user import User
 from src.bot.models.sessions import create_session
 from src.bot.services import user_services
-from src.bot.commands import match_helpers
+from src.bot.commands import helpers, match_helpers
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 from src.bot.callback_handlers.match_callbacks import create_inline_keyboard
 from src.bot.decorators.require_registered_user_decorator import require_register
 
 
-@require_register
-def run_last_match_command(update, user):
-    response, status_code = endpoints.get_player_recent_matches_by_account_id(
-        user.account_id
+def run_last_match_command(update, context):
+    registered_user = user_services.lookup_user_by_telegram_handle(
+        update.message.from_user.username
     )
+
+    args = context.args
+    for arg in context.args:
+        user = user_services.lookup_user_by_telegram_handle(arg)
+        if user:
+            registered_user = user
+            args.remove(arg)
+
+    if args:
+        hero_name = " ".join(args)
+        hero_id = helpers.get_hero_id_by_name_or_alias(hero_name)
+        if not hero_id:
+            update.message.reply_markdown_v2(constants.USER_OR_HERO_NOT_FOUND_MESSAGE)
+
+    if not registered_user:
+        update.message.reply_markdown_v2(constants.USER_NOT_REGISTERED_MESSAGE)
+
+    if 'hero_id' in locals():
+        response, status_code = endpoints.get_player_matches_by_hero_id(
+            registered_user.account_id, hero_id
+        )
+    else:
+        response, status_code = endpoints.get_player_recent_matches_by_account_id(
+            registered_user.account_id
+        )
 
     if status_code != constants.HTTP_STATUS_CODES.OK.value:
         update.message.reply_text(constants.BAD_RESPONSE_MESSAGE)
 
-    output_message = match_helpers.create_match_message(response[0])
-    button = InlineKeyboardButton(
-        "Full match details", callback_data=("match " + str(response[0]["match_id"]))
-    )
-    markup = InlineKeyboardMarkup.from_button(button)
-    update.message.reply_markdown_v2(output_message, reply_markup=markup)
+    try:
+        output_message = match_helpers.create_match_message(response[0])
+        button = InlineKeyboardButton(
+            "Full match details", callback_data=("match " + str(response[0]["match_id"]))
+        )
+        markup = InlineKeyboardMarkup.from_button(button)
+        update.message.reply_markdown_v2(output_message, reply_markup=markup)
+    except IndexError:
+        update.message.reply_markdown_v2("I could not find a match by those criteria, sorry\!")
 
 
 def run_get_match_by_match_id(update, context):

--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -147,9 +147,7 @@ def run_get_player_hero_winrate_command(update, context):
     hero_id = helpers.get_hero_id_by_name_or_alias(hero_name)
 
     if not hero_id:
-        update.message.reply_markdown_v2(
-            "I don't understand which hero you mean, sorry\! Try `/winrate <hero name>`\. If you tried to tag a user, they may not be registered\."
-        )
+        update.message.reply_markdown_v2(constants.USER_OR_HERO_NOT_FOUND_MESSAGE)
 
     response, status_code = endpoints.get_player_hero_stats(registered_user.account_id)
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -13,6 +13,8 @@ MISSING_HERO_ARGUMENT_MESSAGE = "No arguments were given\! Make sure to send a h
 
 HERO_NOT_FOUND_MESSAGE = "I couldn't find a hero by the name %s D:"
 
+USER_OR_HERO_NOT_FOUND_MESSAGE = "I don't understand which hero you mean, sorry\! If you tried to tag a user, they may not be registered\."
+
 
 HELP_TEXT = """
     *Commands*
@@ -37,14 +39,15 @@ WEBSCRAPER_USER_AGENT_HEADER = {
 
 class API_URI_ENDPOINTS(Enum):
     HEALTH_CHECK = "health"
+    MATCH_PROJECT = "project=match_id&project=player_slot&project=radiant_win&project=duration&project=game_mode&project=lobby_type&project=hero_id&project=start_time&project=version&project=kills&project=deaths&project=assists&project=skill&project=xp_per_min&project=gold_per_min&project=hero_damage&project=tower_damage&project=hero_healing&project=last_hits&project=lane&project=lane_role&project=is_roaming&project=cluster&project=leaver_status&project=party_size"
     MATCHES = "matches/%s"
     PLAYERS = "players/%s"
     PLAYERS_BY_RANK = "playersByRank"
     PLAYERS_BY_ACCOUNT_ID = "players/%s"
     HERO_STATS = "heroStats"
     CONSTANTS = "constants/%s"
-    PLAYER_RECENTS_BY_ACCOUNT_ID = "players/%s/recentMatches"
-    PLAYER_MATCHES_BY_HERO = "players/%s/matches?hero_id=%s"
+    PLAYER_RECENTS_BY_ACCOUNT_ID = "players/%s/matches?" + MATCH_PROJECT
+    PLAYER_MATCHES_BY_HERO = "players/%s/matches?hero_id=%s&" + MATCH_PROJECT
     PLAYER_HERO_STATS = "players/%s/heroes"
     HERO_ITEM_POPULARITY = "heroes/%s/itemPopularity"
 


### PR DESCRIPTION
`/lastmatch` can now take both user and hero arguments, in any combination. Passing a hero argument makes it fetch the most recent game played with that hero, if possible. Error messages are in place for when no games can be found, and the error message that catches both unregistered users and arguments that don't match a hero name (also used in `/winrate`) has been standardized in constants.

In order to get all the relevant data from OpenDota, a long string of "project" arguments has also been added to constants, used by both the recent matches and the matches by hero endpoint. This way, each command can always use either endpoint without missing out on data.

Closes #88.