### PR TITLE
Updated_at for users

### DIFF
--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -3,13 +3,14 @@ source ./.env
 cd ./scripts
 
 CURRENT_TIME=$(date "+%Y.%m.%d-%H.%M.%S")
-BACKUP_DIR=/home/connor/sql_backups
+BACKUP_DIR=/home/casper/sql_backups
 
 mkdir $BACKUP_DIR
 
 echo "Creating pg_dump of $POSTGRES_DB"
 PGPASSWORD=$POSTGRES_PASSWORD \
 pg_dump $POSTGRES_DB \
+  -U $POSTGRES_USER \
   -p $DATABASE_PORT \
   -h localhost \
   > $BACKUP_DIR/$POSTGRES_DB-$CURRENT_TIME.backup.sql

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -3,7 +3,7 @@ source ./.env
 cd ./scripts
 
 CURRENT_TIME=$(date "+%Y.%m.%d-%H.%M.%S")
-BACKUP_DIR=/home/casper/sql_backups
+BACKUP_DIR=~/sql_backups
 
 mkdir $BACKUP_DIR
 

--- a/scripts/create_database.sql
+++ b/scripts/create_database.sql
@@ -6,7 +6,7 @@ CREATE DATABASE :db_name;
 CREATE TABLE bot_users (
     user_id SERIAL PRIMARY KEY,
     telegram_handle TEXT NOT NULL UNIQUE,
-    account_id BIGINT NOT NULL UNIQUE,
+    account_id BIGINT NOT NULL,
     chat_id BIGINT NOT NULL,
     updated_at TIMESTAMP NOT NULL
 );

--- a/scripts/create_database.sql
+++ b/scripts/create_database.sql
@@ -8,7 +8,7 @@ CREATE TABLE bot_users (
     telegram_handle TEXT NOT NULL UNIQUE,
     account_id BIGINT NOT NULL,
     chat_id BIGINT NOT NULL,
-    updated_at TIMESTAMP NOT NULL
+    updated_at TIMESTAMP
 );
 
 CREATE TABLE heroes (

--- a/scripts/create_database.sql
+++ b/scripts/create_database.sql
@@ -7,7 +7,8 @@ CREATE TABLE bot_users (
     user_id SERIAL PRIMARY KEY,
     telegram_handle TEXT NOT NULL UNIQUE,
     account_id BIGINT NOT NULL UNIQUE,
-    chat_id BIGINT NOT NULL
+    chat_id BIGINT NOT NULL,
+    updated_at TIMESTAMP NOT NULL
 );
 
 CREATE TABLE heroes (

--- a/scripts/drop_db.sh
+++ b/scripts/drop_db.sh
@@ -2,4 +2,4 @@
 cd ./scripts
 source ../.env
 
-PGPASSWORD=$POSTGRES_PASSWORD dropdb -p $DATABASE_PORT -h localhost $POSTGRES_DB
+PGPASSWORD=$POSTGRES_PASSWORD dropdb -p $DATABASE_PORT -U $POSTGRES_USER -h localhost $POSTGRES_DB

--- a/scripts/standup_db.sh
+++ b/scripts/standup_db.sh
@@ -3,7 +3,7 @@
 cd ./scripts
 source ../.env
 
-PGPASSWORD=$POSTGRES_PASSWORD createdb -p $DATABASE_PORT -h localhost $POSTGRES_DB -w
+PGPASSWORD=$POSTGRES_PASSWORD createdb -p $DATABASE_PORT -h localhost -U $POSTGRES_USER $POSTGRES_DB -w
 
 PGPASSWORD=$POSTGRES_PASSWORD \
 psql -U $POSTGRES_USER \
@@ -11,4 +11,4 @@ psql -U $POSTGRES_USER \
     -p $DATABASE_PORT \
     -v db_name=$POSTGRES_DB \
     -d $POSTGRES_DB \
-    -f create_database.sql 
+    -f create_database.sql

--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -7,6 +7,7 @@ from src.lib import endpoints
 from src import constants
 from steam.steamid import SteamID
 from src.bot.decorators.require_registered_user_decorator import require_register
+from datetime import datetime
 
 
 def save_user(user):
@@ -24,7 +25,7 @@ def run_register_command(update, context):
         identifier = context.args[0]
 
         user = user_services.lookup_user_by_telegram_handle(telegram_handle) or User(
-            telegram_handle, "", chat_id
+            telegram_handle, "", chat_id, datetime.now()
         )
 
         if SteamID(identifier).is_valid():
@@ -40,6 +41,7 @@ def run_register_command(update, context):
                 account_id = account_id_from_vanity
 
         user.account_id = account_id
+        user.updated_at = datetime.now()
         save_user(user)
         update.message.reply_text(
             f"Successfully registered user {telegram_handle} as {SteamID(account_id).community_url}"

--- a/src/bot/models/user.py
+++ b/src/bot/models/user.py
@@ -7,10 +7,6 @@ class User(Base):
 
     __tablename__ = "bot_users"
 
-    __mapper_args__ = {
-        "order_by":updated_at
-    }
-
     def __init__(self, telegram_handle, account_id, chat_id, updated_at):
         self.telegram_handle = telegram_handle
         self.account_id = account_id

--- a/src/bot/models/user.py
+++ b/src/bot/models/user.py
@@ -11,7 +11,7 @@ class User(Base):
         "order_by":updated_at
     }
 
-    def __init__(self, telegram_handle, account_id, chat_id):
+    def __init__(self, telegram_handle, account_id, chat_id, updated_at):
         self.telegram_handle = telegram_handle
         self.account_id = account_id
         self.chat_id = chat_id

--- a/src/bot/models/user.py
+++ b/src/bot/models/user.py
@@ -1,3 +1,4 @@
+from sqlalchemy.sql.sqltypes import DateTime
 from . import Base
 from sqlalchemy import Column, String, Integer, BigInteger
 
@@ -6,12 +7,18 @@ class User(Base):
 
     __tablename__ = "bot_users"
 
+    __mapper_args__ = {
+        "order_by":updated_at
+    }
+
     def __init__(self, telegram_handle, account_id, chat_id):
         self.telegram_handle = telegram_handle
         self.account_id = account_id
         self.chat_id = chat_id
+        self.updated_at = updated_at
 
     user_id = Column(Integer, primary_key=True)
     telegram_handle = Column(String)
     account_id = Column(BigInteger)
     chat_id = Column(BigInteger)
+    updated_at = Column(DateTime)

--- a/src/bot/services/user_services.py
+++ b/src/bot/services/user_services.py
@@ -6,7 +6,7 @@ def lookup_user_by_telegram_handle(telegram_handle):
     telegram_handle = telegram_handle.lower().replace("@", "")
     session = create_session()
     bot_user = (
-        session.query(User).filter(User.telegram_handle == telegram_handle).first()
+        session.query(User).order_by(User.updated_at.desc()).filter(User.telegram_handle == telegram_handle).first()
     )
     session.close()
     return bot_user
@@ -16,6 +16,6 @@ def lookup_user_by_account_id(account_id):
     account_id = int(account_id)
 
     session = create_session()
-    bot_user = session.query(User).filter(User.account_id == account_id).first()
+    bot_user = session.query(User).order_by(User.updated_at.desc()).filter(User.account_id == account_id).first()
     session.close()
     return bot_user

--- a/src/bot/services/user_services.py
+++ b/src/bot/services/user_services.py
@@ -6,7 +6,7 @@ def lookup_user_by_telegram_handle(telegram_handle):
     telegram_handle = telegram_handle.lower().replace("@", "")
     session = create_session()
     bot_user = (
-        session.query(User).order_by(User.updated_at.desc(), User.user_id.desc()).filter(User.telegram_handle == telegram_handle).first()
+        session.query(User).order_by(User.updated_at.desc().nullslast(), User.user_id.desc()).filter(User.telegram_handle == telegram_handle).first()
     )
     session.close()
     return bot_user
@@ -16,6 +16,6 @@ def lookup_user_by_account_id(account_id):
     account_id = int(account_id)
 
     session = create_session()
-    bot_user = session.query(User).order_by(User.updated_at.desc(), User.user_id.desc()).filter(User.account_id == account_id).first()
+    bot_user = session.query(User).order_by(User.updated_at.desc().nullslast(), User.user_id.desc()).filter(User.account_id == account_id).first()
     session.close()
     return bot_user

--- a/src/bot/services/user_services.py
+++ b/src/bot/services/user_services.py
@@ -6,7 +6,7 @@ def lookup_user_by_telegram_handle(telegram_handle):
     telegram_handle = telegram_handle.lower().replace("@", "")
     session = create_session()
     bot_user = (
-        session.query(User).order_by(User.updated_at.desc()).filter(User.telegram_handle == telegram_handle).first()
+        session.query(User).order_by(User.updated_at.desc(), User.user_id.desc()).filter(User.telegram_handle == telegram_handle).first()
     )
     session.close()
     return bot_user
@@ -16,6 +16,6 @@ def lookup_user_by_account_id(account_id):
     account_id = int(account_id)
 
     session = create_session()
-    bot_user = session.query(User).order_by(User.updated_at.desc()).filter(User.account_id == account_id).first()
+    bot_user = session.query(User).order_by(User.updated_at.desc(), User.user_id.desc()).filter(User.account_id == account_id).first()
     session.close()
     return bot_user


### PR DESCRIPTION
This adds a `updated_at` field to the User model and to the database, which is filled in when creating or updating registrations. Queries for users then sort by this field, so the most recently updated user comes up first. This prevents old registrations from coming up in reverse lookups (like in /match). Even when there are multiple users with the same steamid, the name shown is always the most recently registered one.

Something that stood out to me was that the steamid column in the default database schema was unique. I changed this to non-unique, the same way it is in production. With the change I've made here, conflicts where more than one user has the same steamid are always resolved gracefully, by sorting by updated_at. The alternative blocks people from registering an already in use id, which is not desirable imo.

I've also taken the liberty to add some arguments to several database scripts. Just in case the database username is different from the username the script is being executed as.

Fixes #87.