### PR TITLE
Command to explain how to expose and sync match data

### DIFF
--- a/src/bot/bot_factory.py
+++ b/src/bot/bot_factory.py
@@ -10,7 +10,7 @@ from telegram.ext import (
 from src.bot import logger_factory
 from src.bot.commands import health_check_command
 from src.bot.commands import user_commands
-from src.bot.commands import help_command
+from src.bot.commands import help_commands
 from src.bot.commands import match_commands
 from src.bot.commands import changelog_command
 from src.bot.commands import hero_commands
@@ -45,7 +45,7 @@ def create_bot():
             ["recents", "matches"], user_commands.run_get_player_recents_command
         )
     )
-    dp.add_handler(CommandHandler(["help", "start"], help_command.run_help_command))
+    dp.add_handler(CommandHandler(["help", "start"], help_commands.run_help_command))
     dp.add_handler(CommandHandler("lastmatch", match_commands.run_last_match_command))
     dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id))
     dp.add_handler(
@@ -61,6 +61,11 @@ def create_bot():
     dp.add_handler(
         CommandHandler(
             ["counter", "counters"], hero_commands.run_get_hero_counters_command
+        )
+    )
+    dp.add_handler(
+        CommandHandler(
+            ["exposedata", "matchdata"], help_commands.run_expose_data_command
         )
     )
 

--- a/src/bot/commands/help_command.py
+++ b/src/bot/commands/help_command.py
@@ -1,5 +1,0 @@
-from src.constants import HELP_TEXT
-
-
-def run_help_command(update, context):
-    update.message.reply_markdown_v2(HELP_TEXT, quote=False)

--- a/src/bot/commands/help_commands.py
+++ b/src/bot/commands/help_commands.py
@@ -1,0 +1,10 @@
+from src.constants import HELP_TEXT, EXPOSE_DATA_TEXT_PART_ONE, EXPOSE_DATA_TEXT_PART_TWO, EXPOSE_DATA_TEXT_PART_THREE
+
+
+def run_help_command(update, context):
+    update.message.reply_markdown_v2(HELP_TEXT, quote=False)
+
+def run_expose_data_command(update, context):
+    update.message.reply_markdown_v2(EXPOSE_DATA_TEXT_PART_ONE, quote=False)
+    update.message.reply_photo("https://i.ibb.co/MhkhdJT/image.png", caption=EXPOSE_DATA_TEXT_PART_TWO, parse_mode="MarkdownV2", quote=False)
+    update.message.reply_photo("https://i.ibb.co/y0m6kH1/image.png", caption=EXPOSE_DATA_TEXT_PART_THREE, parse_mode="MarkdownV2", quote=False)

--- a/src/constants.py
+++ b/src/constants.py
@@ -30,6 +30,16 @@ HELP_TEXT = """
     `\/counters <hero name>` :: Get a list of heroes that counter the given hero\. Includes win rates and the percent disadvantage\n
     """
 
+EXPOSE_DATA_TEXT_PART_ONE = "If you have registered with Slarkbot but your matches are not showing up, check whether your match data is exposed and whether Opendota has synced up\. To do this, follow these steps:"
+EXPOSE_DATA_TEXT_PART_TWO = """
+*Step one:* Expose your match data in Dota\'s settings, under Social\.\n
+*Step two:* Go to opendota\.com in your browser and log in with your Steam account\.
+"""
+EXPOSE_DATA_TEXT_PART_THREE = """
+*Step three:* On your Opendota profile, click the \"Refresh\" button at the top of the page\. This will make Opendota index all the games it missed from when your match data was set to private\.\n\n
+It can sometimes take a while for Opendota to go over all your games, especially if other people are refreshing their history as well\. If it does not work right away, try again in ten minutes\!
+"""
+
 WEBSCRAPER_USER_AGENT_HEADER = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.128 Safari/537.36"
 }


### PR DESCRIPTION
Added a command under `/exposedata` or `/matchdata` which explains, with illustrations, how to expose your match data in Dota and how to log into Opendota and refresh for missed matches. This command doesn't need to be in the autocomplete, but it's nice to have because explaining this to new users comes up a lot.

Closes #96