### PR TITLE
Hero name placeholder for unknown heroes

### DIFF
--- a/src/bot/commands/match_helpers.py
+++ b/src/bot/commands/match_helpers.py
@@ -28,7 +28,10 @@ def create_recent_matches_message(json_api_data):
 
         hero_id = match.hero_id
         hero_data = hero_services.get_hero_by_id(hero_id)
-        hero_name = hero_data.localized_name
+        try:
+            hero_name = hero_data.localized_name
+        except:
+            hero_name = "Unknown Hero"
 
         kda = f"%s/%s/%s" % (match.kills, match.deaths, match.assists)
 
@@ -50,7 +53,10 @@ def create_match_message(match_data):
 
     hero_id = match.hero_id
     hero_data = hero_services.get_hero_by_id(hero_id)
-    hero_name = hero_data.localized_name
+    try:
+        hero_name = hero_data.localized_name
+    except:
+        hero_name = "Unknown Hero"
 
     duration = str(datetime.timedelta(seconds=match.duration))
 
@@ -133,7 +139,10 @@ def build_default_match_message(match, player_data):
             bot_user = user_services.lookup_user_by_account_id(player.account_id)
             if bot_user:
                 hero_data = hero_services.get_hero_by_id(player.hero_id)
-                hero_name = hero_data.localized_name
+                try:
+                    hero_name = hero_data.localized_name
+                except:
+                    hero_name = "Unknown Hero"
 
                 known_players.append(f"{bot_user.telegram_handle} ({hero_name})")
 
@@ -166,7 +175,10 @@ def build_default_player_string(player):
     gpm = player.gold_per_min
 
     hero_data = hero_services.get_hero_by_id(player.hero_id)
-    hero_name = hero_data.localized_name
+    try:
+        hero_name = hero_data.localized_name
+    except:
+        hero_name = "Unknown Hero"
 
     return f"{kda} | L{level} | {cs} | {gpm} GPM | {xpm} XPM | {hero_name}\n"
 
@@ -196,7 +208,10 @@ def build_players_player_line(player):
         player_name = "Anonymous"
 
     hero_data = hero_services.get_hero_by_id(player.hero_id)
-    hero_name = hero_data.localized_name
+    try:
+        hero_name = hero_data.localized_name
+    except:
+        hero_name = "Unknown Hero"
 
     if player.rank_tier:
         rank = f"| {helpers.map_rank_tier_to_string(player.rank_tier)}"
@@ -232,7 +247,10 @@ def build_damage_player_line(player):
     healing = player.hero_healing
 
     hero_data = hero_services.get_hero_by_id(player.hero_id)
-    hero_name = hero_data.localized_name
+    try:
+        hero_name = hero_data.localized_name
+    except:
+        hero_name = "Unknown Hero"
 
     return f"{damage} DMG | {building_damage} TD | {healing} H | {hero_name}\n"
 
@@ -267,7 +285,10 @@ def build_pick_order_match_message(match, player_data):
     banned_heroes = []
     for ban in bans:
         hero_data = hero_services.get_hero_by_id(ban)
-        hero_name = hero_data.localized_name
+        try:
+            hero_name = hero_data.localized_name
+        except:
+            hero_name = "Unknown Hero"
 
         banned_heroes.append(hero_name)
 
@@ -289,6 +310,9 @@ def build_pick_order_player_line(player, picks_ordered):
         pick_string = "Last pick"
 
     hero_data = hero_services.get_hero_by_id(player.hero_id)
-    hero_name = hero_data.localized_name
+    try:
+        hero_name = hero_data.localized_name
+    except:
+        hero_name = "Unknown Hero"
 
     return f"{hero_name}: {pick_string}\n"


### PR DESCRIPTION
When a new hero is added to the game, the bot always throws exceptions trying to name it, since it's not yet in our constants file. This change replaces all instances of that exception with "Unknown Hero", so outputs go through even when we haven't updated constants yet.